### PR TITLE
Add __wrapped__ attribute to chai decorated test methods

### DIFF
--- a/chai/chai.py
+++ b/chai/chai.py
@@ -56,6 +56,7 @@ class ChaiTestType(type):
     wrapper.__name__ = func.__name__
     wrapper.__doc__ = func.__doc__
     wrapper.__module__ = func.__module__
+    wrapper.__wrapped__ = func
     return wrapper
 
 class Chai(unittest.TestCase):


### PR DESCRIPTION
This is also added by functools.wraps as of python 3.2:  http://hg.python.org/cpython/file/3.2/Lib/functools.py#l41

This is useful as it allows someone to get at the wrapped test method to do introspection.
