### PR TITLE
Unmet expectations no longer ignored

### DIFF
--- a/chai/chai.py
+++ b/chai/chai.py
@@ -69,18 +69,17 @@ class ChaiTestType(type):
         # called during exception handling (e.g. "open"), the original method
         # is used. Without, recursion limits are common with little insight
         # into what went wrong.
+        exceptions = []
         try:
           for stub in self._stubs:
+            # Make sure we collect any unmet expectations before teardown.
+            exceptions.extend(stub.unmet_expectations())
             stub.teardown()
         except:
           # A rare case where this is about the best that can be done, as we
           # don't want to supersede the actual exception if there is one.
           traceback.print_exc()
 
-      exceptions = []
-      for stub in self._stubs:
-        exceptions.extend(stub.unmet_expectations())
-      
       if exceptions:
         raise ExpectationNotSatisfied(*exceptions)
       

--- a/chai/exception.py
+++ b/chai/exception.py
@@ -74,7 +74,7 @@ class ExpectationNotSatisfied(ChaiAssertion):
   '''
   
   def __init__(self, *expectations):
-    self._expections = expectations
+    self._expectations = expectations
   
   def __str__(self):
-    return str("\n".join([ str(e) for e in self._expections]))
+    return str("\n".join([ str(e) for e in self._expectations]))

--- a/tests/chai_test.py
+++ b/tests/chai_test.py
@@ -171,3 +171,13 @@ class ChaiTest(unittest.TestCase):
     case.test_local_definitions_work_and_are_global()
     self.assertEquals(1, stub.unmet_calls)
     self.assertEquals(1, stub.teardown_calls)
+
+  def test_raises_if_unmet_expectations(self):
+    class Milk(object):
+        def pour(self): pass
+    milk = Milk()
+    case = CupOf()
+    stub = Stub(milk.pour)
+    stub.expect()
+    case._stubs = deque([stub])
+    self.assertRaises(ExpectationNotSatisfied, case.test_something)


### PR DESCRIPTION
This fixes the issue identified in https://github.com/agoragames/chai/issues/15 .

I assume we want to keep the behavior of tearing down all stubs immediately after the test, so I simply handled the collection of unmet_expectations just before the teardown.
