### PR TITLE
Add ChaiBase.mock_of(interface) to create mock objects that have isinstance(mock, interface) = True

### DIFF
--- a/chai/chai.py
+++ b/chai/chai.py
@@ -259,7 +259,7 @@ class ChaiBase(unittest.TestCase):
                     return issubclass(mock_interface, cls)
             return self._original_instance_checks[type(cls)](cls, instance)
 
-        mock = Mock(**kwargs)
+        mock = self.mock(**kwargs)
         mock._interface = interface
         if meta_cls not in self._original_instance_checks:
             self._original_instance_checks[meta_cls] = meta_cls.__instancecheck__

--- a/chai/chai.py
+++ b/chai/chai.py
@@ -11,10 +11,7 @@ try:
 except ImportError:
     import unittest
 
-import re
-import sys
 import inspect
-import traceback
 from collections import deque
 
 from .exception import *
@@ -253,15 +250,14 @@ class ChaiBase(unittest.TestCase):
         '''
         Return a mock object that is an instance of a given abc interface.
         '''
-        assert hasattr(interface, '__metaclass__')
-        meta_cls = interface.__metaclass__
+        meta_cls = type(interface)
 
         def _instance_check(cls, instance):
             if type(instance) is Mock:
                 mock_interface = getattr(instance, '_interface', None)
                 if mock_interface is not None:
                     return issubclass(mock_interface, cls)
-            return self._original_instance_checks[cls.__metaclass__](cls, instance)
+            return self._original_instance_checks[type(cls)](cls, instance)
 
         mock = Mock(**kwargs)
         mock._interface = interface

--- a/chai/chai.py
+++ b/chai/chai.py
@@ -22,15 +22,6 @@ from .mock import Mock
 from .stub import stub
 from .comparators import *
 
-_original_instance_checks = {}
-
-def _instance_check(cls, instance):
-    if type(instance) is Mock:
-        mock_interface = getattr(instance, '_interface', None)
-        if mock_interface is not None:
-            return issubclass(mock_interface, cls)
-    return _original_instance_checks[cls.__metaclass__](cls, instance)
-
 
 class ChaiTestType(type):
 

--- a/tests/mock_of_test.py
+++ b/tests/mock_of_test.py
@@ -1,0 +1,101 @@
+'''
+Tests for the Chai.mock_of() method
+'''
+
+import abc
+
+from chai import Chai
+
+class ABCInterface(object):
+  __metaclass__ = abc.ABCMeta
+
+  @abc.abstractmethod
+  def do_you_mock_me(self):
+    pass
+
+  @abc.abstractmethod
+  def some_other_function(self):
+    pass
+
+
+class ConcreteClass(ABCInterface):
+    def do_you_mock_me(self):
+        return True
+
+    def some_other_function(self):
+        return False
+
+
+def a_function(x):
+  assert isinstance(x, ABCInterface)
+  if x.do_you_mock_me():
+    return 'Hooray'
+  else:
+    return 'Why not?'
+
+
+class ContractMeta(abc.ABCMeta):
+  pass
+
+
+class ContractInterface(object):
+  __metaclass__ = ContractMeta
+
+  @abc.abstractmethod
+  def do_you_mock_me(self):
+    pass
+
+
+class ContractClass(ContractInterface):
+    def do_you_mock_me(self):
+        return 'of course I do'
+
+
+def c_function(x):
+  assert isinstance(x, ContractInterface)
+  if x.do_you_mock_me():
+    return 'Hooray'
+  else:
+    return 'Why not?'
+
+
+class MockOfTest(Chai):
+
+  def test_assert_is_instance(self):
+      # Arrange
+      mockable = self.mock_of(ABCInterface)
+      self.assertIsInstance(mockable, ABCInterface)
+
+  def test_caller_asserts_pass(self):
+      mockable = self.mock_of(ABCInterface)
+      self.expect(mockable.do_you_mock_me).returns(True).once()
+
+      result = a_function(mockable)
+
+      self.assertEqual(result, 'Hooray')
+
+  def test_inherited_instancecheck(self):
+      mockable = self.mock_of(ContractInterface)
+      self.assertIn('__instancecheck__', ContractMeta.__dict__)
+      self.expect(mockable.do_you_mock_me).returns(True).once()
+
+      result = c_function(mockable)
+
+      self.assertEqual(result, 'Hooray')
+
+  def test_isinstance_still_works_for_real_instances(self):
+      mockable = self.mock_of(ABCInterface)
+      a = ConcreteClass()
+      self.assertIsInstance(a, ABCInterface)
+
+  def test_isinstance_fails_nicely(self):
+      mockable = self.mock_of(ABCInterface)
+      c = ContractClass()
+      self.assertFalse(isinstance(c, ABCInterface))
+      self.assertFalse(isinstance(6, ABCInterface))
+      self.assertFalse(isinstance([], ABCInterface))
+
+  def tearDown(self):
+      Chai.tearDown(self)
+      # check tidy up for test_inherited_instancecheck
+      assert '__instancecheck__' not in ContractMeta.__dict__

--- a/tests/mock_of_test.py
+++ b/tests/mock_of_test.py
@@ -4,21 +4,32 @@ Tests for the Chai.mock_of() method
 
 import abc
 
+from six import with_metaclass
+
 from chai import Chai
 
-class ABCInterface(object):
-  __metaclass__ = abc.ABCMeta
-
-  @abc.abstractmethod
-  def do_you_mock_me(self):
-    pass
-
-  @abc.abstractmethod
-  def some_other_function(self):
+class ContractMeta(abc.ABCMeta):
     pass
 
 
-class ConcreteClass(ABCInterface):
+class ABCInterface(with_metaclass(abc.ABCMeta)):
+    @abc.abstractmethod
+    def do_you_mock_me(self):
+        pass
+
+    @abc.abstractmethod
+    def some_other_function(self):
+        pass
+
+
+class ContractInterface(with_metaclass(ContractMeta)):
+
+    @abc.abstractmethod
+    def do_you_mock_me(self):
+        pass
+
+
+class AClass(ABCInterface):
     def do_you_mock_me(self):
         return True
 
@@ -26,76 +37,63 @@ class ConcreteClass(ABCInterface):
         return False
 
 
-def a_function(x):
-  assert isinstance(x, ABCInterface)
-  if x.do_you_mock_me():
-    return 'Hooray'
-  else:
-    return 'Why not?'
-
-
-class ContractMeta(abc.ABCMeta):
-  pass
-
-
-class ContractInterface(object):
-  __metaclass__ = ContractMeta
-
-  @abc.abstractmethod
-  def do_you_mock_me(self):
-    pass
-
-
 class ContractClass(ContractInterface):
     def do_you_mock_me(self):
         return 'of course I do'
 
 
+def a_function(x):
+    assert isinstance(x, ABCInterface)
+    if x.do_you_mock_me():
+        return 'Hooray'
+    else:
+        return 'Why not?'
+
+
 def c_function(x):
-  assert isinstance(x, ContractInterface)
-  if x.do_you_mock_me():
-    return 'Hooray'
-  else:
-    return 'Why not?'
+    assert isinstance(x, ContractInterface)
+    if x.do_you_mock_me():
+        return 'Hooray'
+    else:
+        return 'Why not?'
 
 
 class MockOfTest(Chai):
+    def test_assert_is_instance(self):
+        # Arrange
+        mockable = self.mock_of(ABCInterface)
+        self.assertIsInstance(mockable, ABCInterface)
 
-  def test_assert_is_instance(self):
-      # Arrange
-      mockable = self.mock_of(ABCInterface)
-      self.assertIsInstance(mockable, ABCInterface)
+    def test_caller_asserts_pass(self):
+        mockable = self.mock_of(ABCInterface)
+        self.expect(mockable.do_you_mock_me).returns(True).once()
 
-  def test_caller_asserts_pass(self):
-      mockable = self.mock_of(ABCInterface)
-      self.expect(mockable.do_you_mock_me).returns(True).once()
+        result = a_function(mockable)
 
-      result = a_function(mockable)
+        self.assertEqual(result, 'Hooray')
 
-      self.assertEqual(result, 'Hooray')
+    def test_inherited_instancecheck(self):
+        mockable = self.mock_of(ContractInterface)
+        self.assertIn('__instancecheck__', ContractMeta.__dict__)
+        self.expect(mockable.do_you_mock_me).returns(True).once()
 
-  def test_inherited_instancecheck(self):
-      mockable = self.mock_of(ContractInterface)
-      self.assertIn('__instancecheck__', ContractMeta.__dict__)
-      self.expect(mockable.do_you_mock_me).returns(True).once()
+        result = c_function(mockable)
 
-      result = c_function(mockable)
+        self.assertEqual(result, 'Hooray')
 
-      self.assertEqual(result, 'Hooray')
+    def test_isinstance_still_works_for_real_instances(self):
+        mockable = self.mock_of(ABCInterface)
+        a = AClass()
+        self.assertIsInstance(a, ABCInterface)
 
-  def test_isinstance_still_works_for_real_instances(self):
-      mockable = self.mock_of(ABCInterface)
-      a = ConcreteClass()
-      self.assertIsInstance(a, ABCInterface)
+    def test_isinstance_fails_nicely(self):
+        mockable = self.mock_of(ABCInterface)
+        c = ContractClass()
+        self.assertFalse(isinstance(c, ABCInterface))
+        self.assertFalse(isinstance(6, ABCInterface))
+        self.assertFalse(isinstance([], ABCInterface))
 
-  def test_isinstance_fails_nicely(self):
-      mockable = self.mock_of(ABCInterface)
-      c = ContractClass()
-      self.assertFalse(isinstance(c, ABCInterface))
-      self.assertFalse(isinstance(6, ABCInterface))
-      self.assertFalse(isinstance([], ABCInterface))
-
-  def tearDown(self):
-      Chai.tearDown(self)
-      # check tidy up for test_inherited_instancecheck
-      assert '__instancecheck__' not in ContractMeta.__dict__
+    def tearDown(self):
+        Chai.tearDown(self)
+        # check tidy up for test_inherited_instancecheck
+        assert '__instancecheck__' not in ContractMeta.__dict__


### PR DESCRIPTION
The use of isinstance checks on parameter values is quite common when using the abc module or PyContracts.  The mock_of() method returns a Mock() instance that passes the isinstance test.

The interface class passed to mock_of must have a meta-class so that we can override the **instancecheck** method on it.  This is always the case with interface classes created with the abc module or PyContracts.
