### PR TITLE
Fix testing of `expect(foo).times(0)`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - "3.6"
   - "3.4"
   - "3.3"
   - "2.7"

--- a/chai/expectation.py
+++ b/chai/expectation.py
@@ -260,7 +260,7 @@ class Expectation(object):
 
     def counts_met(self):
         return self._run_count >= self._min_count and not (
-            self._max_count and not self._max_count == self._run_count)
+            self._max_count is not None and not self._max_count == self._run_count)
 
     def match(self, *args, **kwargs):
         """


### PR DESCRIPTION
This is similar to `stub(foo)` but is a more self-documenting approach that some developers favor.  It also results in an `ExpectationNotSatisfied` report at the end, vs. throwing an `UnexpectedCall` at the time `foo` is called.